### PR TITLE
Upgraded compileSdkVersion to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
With the new AndroidX and googles upgrade I had some problems with the old compileSdkVersion.

namely this when I tried to build an APK:

```
2769 FAILURE: Build failed with an exception.
2770 * What went wrong:
2771 Execution failed for task ':flutter_sodium:verifyReleaseResources'.
2772 > java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
2773   /builds/app/build/flutter_sodium/intermediates/res/merged/release/values/values.xml:236: error: resource android:attr/fontVariationSettings not found.
2774   /builds/app/build/flutter_sodium/intermediates/res/merged/release/values/values.xml:237: error: resource android:attr/ttcIndex not found.
2775   error: failed linking references.
2776 * Try:
2777 Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
2778 * Get more help at https://help.gradle.org
2779 BUILD FAILED in 6m 58s
2780 Running Gradle task 'assembleRelease'...                          420.2s (!)
2781 Gradle task assembleRelease failed with exit code 1
```

This PR ugprades compileSdkVersion to 28 and fixes the errors.