### PR TITLE
adds support for loading libsodium on linux

### DIFF
--- a/lib/src/bindings/libsodium.dart
+++ b/lib/src/bindings/libsodium.dart
@@ -17,6 +17,11 @@ DynamicLibrary _load() {
     // see also https://libsodium.gitbook.io/doc/installation
     return DynamicLibrary.open('/usr/local/lib/libsodium.dylib');
   }
+  if (Platform.isLinux) {
+    // assuming user installed libsodium as per the installation instructions
+    // see also https://libsodium.gitbook.io/doc/installation
+    return DynamicLibrary.open('/usr/local/lib/libsodium.so');
+  }
   throw SodiumException('platform not supported');
 }
 


### PR DESCRIPTION
- verified with libsodium 1.0.18-stable on ubuntu 20.10