### PR TITLE
Added suppport for loading libsodium on Windows

### DIFF
--- a/lib/src/bindings/libsodium.dart
+++ b/lib/src/bindings/libsodium.dart
@@ -22,6 +22,11 @@ DynamicLibrary _load() {
     // see also https://libsodium.gitbook.io/doc/installation
     return DynamicLibrary.open('/usr/local/lib/libsodium.so');
   }
+  if (Platform.isWindows) {
+    // assuming user installed libsodium as per the installation instructions
+    // see also https://py-ipv8.readthedocs.io/en/latest/preliminaries/install_libsodium/
+    return DynamicLibrary.open('C:\\Windows\\System32\\libsodium.dll');
+  }
   throw SodiumException('platform not supported');
 }
 


### PR DESCRIPTION
- verified with libsodium 1.0.18-stable on Windows 10 Pro version 1909 (OS build18363.1256)