### PR TITLE
Using relative library path for Linux

### DIFF
--- a/lib/src/bindings/libsodium.dart
+++ b/lib/src/bindings/libsodium.dart
@@ -20,7 +20,7 @@ DynamicLibrary _load() {
   if (Platform.isLinux) {
     // assuming user installed libsodium as per the installation instructions
     // see also https://libsodium.gitbook.io/doc/installation
-    return DynamicLibrary.open('/usr/local/lib/libsodium.so');
+    return DynamicLibrary.open('libsodium.so.23');
   }
   if (Platform.isWindows) {
     // assuming user installed libsodium as per the installation instructions


### PR DESCRIPTION
`libsodium.so.23` name convention is used in many DEB and RPM-based distributions, so using the relative path is a logical step. I tested this on the latest Fedora and Ubuntu and did not notice any problems. As an option, I can add a check for the presence of `libsodium.so` besides `libsodium.so.23`.

![](https://user-images.githubusercontent.com/7840559/132049206-3d54cf1b-ca54-4641-a823-38e1783e5fe9.png)
